### PR TITLE
Add CodeSourceLink block

### DIFF
--- a/pkg/blocks/CodeSourceLink/CodeSourceLink.tsx
+++ b/pkg/blocks/CodeSourceLink/CodeSourceLink.tsx
@@ -1,0 +1,49 @@
+import { css, cx } from "@linaria/core";
+import * as React from "react";
+import IconCode from "./IconCode";
+
+/**
+ * The underlying DOM element which is rendered by this component.
+ */
+const Root = "a";
+
+interface Props extends React.ComponentProps<typeof Root> {
+  // default is a code icon
+  icon?: React.ReactNode;
+  noIcon?: boolean;
+  url: string;
+}
+
+function CodeSourceLink(props: Props, ref: React.ForwardedRef<React.ElementRef<typeof Root>>) {
+  const { noIcon, icon = <IconCode style={{ marginRight: "8px" }} />, url, children, className, ...rest } = props;
+
+  return (
+    <Root ref={ref} href={url} className={cx(className, classes.root)} {...rest}>
+      {/* use fragment to fix single node error */}
+      <>
+        {!noIcon && icon}
+        {children}
+      </>
+    </Root>
+  );
+}
+
+export default React.forwardRef(CodeSourceLink);
+
+const classes = {
+  root: css`
+    display: flex;
+    background-color: var(--c-p-0);
+    border: 1px solid var(--c-p-2);
+    color: var(--timvir-text-color);
+    border-radius: 4px;
+    align-items: center;
+    justify-content: center;
+    padding: 8px;
+    text-decoration: none;
+    &:hover {
+      border-color: var(--c-p-4);
+      color: var(--c-p-5);
+    }
+  `,
+};

--- a/pkg/blocks/CodeSourceLink/IconCode.tsx
+++ b/pkg/blocks/CodeSourceLink/IconCode.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+/**
+ * Copyright: blueprint
+ */
+const Root = "svg";
+
+interface Props extends React.ComponentProps<typeof Root> {}
+
+export default function IconCode(props: Props) {
+  return (
+    <svg data-icon="code" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" {...props}>
+      <path
+        d="M15.71 7.29l-3-3a1.003 1.003 0 00-1.42 1.42L13.59 8l-2.29 2.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71l3-3c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71zM5 5a1.003 1.003 0 00-1.71-.71l-3 3C.11 7.47 0 7.72 0 8c0 .28.11.53.29.71l3 3a1.003 1.003 0 001.42-1.42L2.41 8 4.7 5.71c.19-.18.3-.43.3-.71zm4-3c-.48 0-.87.35-.96.81l-2 10c-.01.06-.04.12-.04.19 0 .55.45 1 1 1 .48 0 .87-.35.96-.81l2-10c.01-.06.04-.12.04-.19 0-.55-.45-1-1-1z"
+        fillRule="evenodd"
+      ></path>
+    </svg>
+  );
+}

--- a/pkg/blocks/CodeSourceLink/docs/index.mdx
+++ b/pkg/blocks/CodeSourceLink/docs/index.mdx
@@ -1,0 +1,42 @@
+import { Exhibit } from "../../Exhibit";
+import { Code } from "@timvir/blocks";
+
+# CodeSourceLink
+
+The `<CodeSourceLink>` is a block created for link to GitHub source code page. In general is a link component, so you could use it to link to any external site.
+
+<Sample variant="basic" />
+
+## Usage
+
+```jsx
+import { CodeSourceLink } from "timvir/blocks";
+
+<CodeSourceLink url="https://github.com/timvir">
+  <div>View source on Github</div>
+</CodeSourceLink>;
+```
+
+<Exhibit caption="noIcon" bleed={8}>
+  <Sample variant="basic" noIcon />
+</Exhibit>
+
+<Exhibit caption="other icon" bleed={8}>
+  <Sample
+    variant="basic"
+    icon={
+      <svg
+        data-icon="duplicate"
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        style={{ fill: "currentColor", marginRight: "8px" }}
+      >
+        <path
+          d="M15 0H5c-.55 0-1 .45-1 1v2h2V2h8v7h-1v2h2c.55 0 1-.45 1-1V1c0-.55-.45-1-1-1zm-4 4H1c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h10c.55 0 1-.45 1-1V5c0-.55-.45-1-1-1zm-1 10H2V6h8v8z"
+          fill-rule="evenodd"
+        ></path>
+      </svg>
+    }
+  />
+</Exhibit>

--- a/pkg/blocks/CodeSourceLink/index.ts
+++ b/pkg/blocks/CodeSourceLink/index.ts
@@ -1,0 +1,1 @@
+export { default as CodeSourceLink } from "./CodeSourceLink";

--- a/pkg/blocks/CodeSourceLink/samples/basic.tsx
+++ b/pkg/blocks/CodeSourceLink/samples/basic.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { CodeSourceLink } from "..";
+
+type Props = Partial<React.ComponentPropsWithoutRef<typeof CodeSourceLink>>;
+
+export default function Sample(props: Props) {
+  return (
+    <CodeSourceLink
+      url="https://github.com/timvir/timvir/tree/master/pkg/timvir/blocks/CodeSourceLink/CodeSourceLink"
+      {...props}
+    >
+      <div>View source on Github</div>
+    </CodeSourceLink>
+  );
+}

--- a/pkg/blocks/index.ts
+++ b/pkg/blocks/index.ts
@@ -1,5 +1,6 @@
 export { Arbitrary } from "@timvir/blocks/Arbitrary";
 export { Code } from "@timvir/blocks/Code";
+export { CodeSourceLink } from "@timvir/blocks/CodeSourceLink";
 export { ColorBar } from "@timvir/blocks/ColorBar";
 export { ColorBook } from "@timvir/blocks/ColorBook";
 export { Cover } from "@timvir/blocks/Cover";

--- a/pkg/timvir/blocks/CodeSourceLink/CodeSourceLink.tsx
+++ b/pkg/timvir/blocks/CodeSourceLink/CodeSourceLink.tsx
@@ -1,0 +1,56 @@
+import { css, cx } from "@linaria/core";
+import * as React from "react";
+import IconCode from "./IconCode";
+
+/**
+ * The underlying DOM element which is rendered by this component.
+ */
+const Root = "a";
+
+interface Props extends React.ComponentProps<typeof Root> {
+  // default is a code icon
+  icon?: React.ReactNode;
+  noIcon?: boolean;
+  url: string;
+}
+
+function CodeSourceLink(props: Props, ref: React.ForwardedRef<React.ElementRef<typeof Root>>) {
+  const {
+    noIcon,
+    icon = <IconCode style={{ marginRight: "8px" }} />,
+    url,
+    children = "View source on Github",
+    className,
+    ...rest
+  } = props;
+
+  return (
+    <Root ref={ref} href={url} className={cx(className, classes.root)} {...rest}>
+      {/* use fragment to fix single node error */}
+      <>
+        {!noIcon && icon}
+        {children}
+      </>
+    </Root>
+  );
+}
+
+export default React.forwardRef(CodeSourceLink);
+
+const classes = {
+  root: css`
+    display: flex;
+    background-color: var(--c-p-0);
+    border: 1px solid var(--c-p-2);
+    color: var(--timvir-text-color);
+    border-radius: 4px;
+    align-items: center;
+    justify-content: center;
+    padding: 8px;
+    text-decoration: none;
+    &:hover {
+      border-color: var(--c-p-4);
+      color: var(--c-p-5);
+    }
+  `,
+};

--- a/pkg/timvir/blocks/CodeSourceLink/IconCode.tsx
+++ b/pkg/timvir/blocks/CodeSourceLink/IconCode.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+/**
+ * Copyright: blueprint
+ */
+const Root = "svg";
+
+interface Props extends React.ComponentProps<typeof Root> {}
+
+export default function IconCode(props: Props) {
+  return (
+    <svg data-icon="code" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" {...props}>
+      <path
+        d="M15.71 7.29l-3-3a1.003 1.003 0 00-1.42 1.42L13.59 8l-2.29 2.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71l3-3c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71zM5 5a1.003 1.003 0 00-1.71-.71l-3 3C.11 7.47 0 7.72 0 8c0 .28.11.53.29.71l3 3a1.003 1.003 0 001.42-1.42L2.41 8 4.7 5.71c.19-.18.3-.43.3-.71zm4-3c-.48 0-.87.35-.96.81l-2 10c-.01.06-.04.12-.04.19 0 .55.45 1 1 1 .48 0 .87-.35.96-.81l2-10c.01-.06.04-.12.04-.19 0-.55-.45-1-1-1z"
+        fillRule="evenodd"
+      ></path>
+    </svg>
+  );
+}

--- a/pkg/timvir/blocks/CodeSourceLink/docs/index.mdx
+++ b/pkg/timvir/blocks/CodeSourceLink/docs/index.mdx
@@ -1,0 +1,42 @@
+import { Exhibit } from "../../Exhibit";
+import { Code } from "@timvir/blocks";
+
+# CodeSourceLink
+
+The `<CodeSourceLink>` is a block created for link to GitHub source code page. In general is a link component, so you could use it to link to any external site.
+
+<Sample variant="basic" />
+
+## Usage
+
+```jsx
+import { CodeSourceLink } from "timvir/blocks";
+
+<CodeSourceLink url="https://github.com/timvir">
+  <div>View source on Github</div>
+</CodeSourceLink>;
+```
+
+<Exhibit caption="noIcon" bleed={8}>
+  <Sample variant="basic" noIcon />
+</Exhibit>
+
+<Exhibit caption="other icon" bleed={8}>
+  <Sample
+    variant="basic"
+    icon={
+      <svg
+        data-icon="duplicate"
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        style={{ fill: "currentColor", marginRight: "8px" }}
+      >
+        <path
+          d="M15 0H5c-.55 0-1 .45-1 1v2h2V2h8v7h-1v2h2c.55 0 1-.45 1-1V1c0-.55-.45-1-1-1zm-4 4H1c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h10c.55 0 1-.45 1-1V5c0-.55-.45-1-1-1zm-1 10H2V6h8v8z"
+          fill-rule="evenodd"
+        ></path>
+      </svg>
+    }
+  />
+</Exhibit>

--- a/pkg/timvir/blocks/CodeSourceLink/index.ts
+++ b/pkg/timvir/blocks/CodeSourceLink/index.ts
@@ -1,0 +1,1 @@
+export { default as CodeSourceLink } from "./CodeSourceLink";

--- a/pkg/timvir/blocks/CodeSourceLink/samples/basic.tsx
+++ b/pkg/timvir/blocks/CodeSourceLink/samples/basic.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { CodeSourceLink } from "..";
+
+type Props = Partial<React.ComponentPropsWithoutRef<typeof CodeSourceLink>>;
+
+export default function Sample(props: Props) {
+  return (
+    <CodeSourceLink
+      url="https://github.com/timvir/timvir/tree/master/pkg/timvir/blocks/CodeSourceLink/CodeSourceLink"
+      {...props}
+    >
+      <div>View source on Github</div>
+    </CodeSourceLink>
+  );
+}

--- a/pkg/timvir/blocks/index.ts
+++ b/pkg/timvir/blocks/index.ts
@@ -1,5 +1,6 @@
 export { Arbitrary } from "timvir/blocks/Arbitrary";
 export { Code } from "timvir/blocks/Code";
+export { CodeSourceLink } from "@timvir/blocks/CodeSourceLink";
 export { ColorBar } from "timvir/blocks/ColorBar";
 export { ColorBook } from "timvir/blocks/ColorBook";
 export { Cover } from "timvir/blocks/Cover";

--- a/src/pages/blocks/[block]/index.tsx
+++ b/src/pages/blocks/[block]/index.tsx
@@ -26,6 +26,7 @@ export default function Page({ block }: Props) {
       [
         "Arbitrary",
         "Code",
+        "CodeSourceLink",
         "ColorBar",
         "ColorBook",
         "Cover",

--- a/src/timvir/toc.ts
+++ b/src/timvir/toc.ts
@@ -27,6 +27,7 @@ export default [
     children: [
       { label: "Arbitrary", path: "/blocks/Arbitrary" },
       { label: "Code", path: "/blocks/Code" },
+      { label: "CodeSourceLink", path: "/blocks/CodeSourceLink" },
       { label: "ColorBar", path: "/blocks/ColorBar" },
       { label: "ColorBook", path: "/blocks/ColorBook" },
       { label: "Cover", path: "/blocks/Cover" },


### PR DESCRIPTION
* Add `CodeSourceLink` in both `pkg/blocks` and `timvir/blocks`
* I avoided to use `useBlock` which need the context

<img width="927" alt="image" src="https://user-images.githubusercontent.com/6782188/168820008-22addbcb-3524-45e1-9d02-2e18b8229c8f.png">
