### PR TITLE
Add well-known classes to blocks

### DIFF
--- a/pkg/timvir/blocks/Arbitrary/Arbitrary.tsx
+++ b/pkg/timvir/blocks/Arbitrary/Arbitrary.tsx
@@ -44,12 +44,12 @@ function Arbitrary(props: Props, ref: React.ForwardedRef<React.ElementRef<typeof
 
   return (
     <Context.Provider value={value}>
-      <Root ref={ref} className={cx(classes.root, className)} {...rest}>
+      <Root ref={ref} className={cx("timvir-b-Arbitrary", classes.root, className)} {...rest}>
         <div className={classes.controls}>
           <div className={classes.textField}>
             <span className={classes.startAdornment}>Seed:</span>
             <input
-              className={classes.input}
+              className={cx("timvir-b-Arbitrary-seed", classes.input)}
               placeholder="Seed"
               value={base58.encode(new TextEncoder().encode(`${value.seed}`))}
               readOnly

--- a/pkg/timvir/blocks/Code/Code.tsx
+++ b/pkg/timvir/blocks/Code/Code.tsx
@@ -90,8 +90,8 @@ function Code(props: Props, ref: React.ForwardedRef<React.ElementRef<typeof Root
   }, [mutate, children, language]);
 
   return (
-    <Root ref={ref} className={cx(classes.root, fullWidth && Page.fullWidth)} {...rest}>
-      <div className={cx(className, theme, classes.code, fullWidth && classes.fullWidth)}>
+    <Root ref={ref} className={cx("timvir-b-Code", classes.root, fullWidth && Page.fullWidth)} {...rest}>
+      <div className={cx("timvir-b-Code-container", className, theme, classes.code, fullWidth && classes.fullWidth)}>
         <div
           className={css`
             display: grid;
@@ -197,7 +197,7 @@ function Code(props: Props, ref: React.ForwardedRef<React.ElementRef<typeof Root
         </div>
       </div>
 
-      {caption && <div className={classes.caption}>{caption}</div>}
+      {caption && <div className={cx("timvir-b-Code-caption", classes.caption)}>{caption}</div>}
     </Root>
   );
 }

--- a/pkg/timvir/blocks/Exhibit/Exhibit.tsx
+++ b/pkg/timvir/blocks/Exhibit/Exhibit.tsx
@@ -33,7 +33,7 @@ function Exhibit(props: Props, ref: React.ForwardedRef<React.ElementRef<typeof R
 
       <Root
         ref={ref}
-        className={cx(className, classes.root)}
+        className={cx("timvir-b-Exhibit", className, classes.root)}
         style={{
           ...style,
           [cssVariables.bleed]: typeof bleed === "number" ? `${bleed}px` : undefined,
@@ -41,7 +41,7 @@ function Exhibit(props: Props, ref: React.ForwardedRef<React.ElementRef<typeof R
         {...rest}
       >
         <div
-          className={classes.container}
+          className={cx("timvir-b-Exhibit-container", classes.container)}
           {...BackdropProps}
           style={{
             border: bleed === 0 ? "none" : `1px solid var(${cssVariables.borderColor})`,
@@ -51,7 +51,7 @@ function Exhibit(props: Props, ref: React.ForwardedRef<React.ElementRef<typeof R
           {children}
         </div>
 
-        {caption && <div className={classes.caption}>{caption}</div>}
+        {caption && <div className={cx("timvir-b-Exhibit-caption", classes.caption)}>{caption}</div>}
       </Root>
     </>
   );

--- a/pkg/timvir/blocks/Viewport/Viewport.tsx
+++ b/pkg/timvir/blocks/Viewport/Viewport.tsx
@@ -132,6 +132,7 @@ function Viewport(props: Props, ref: React.ForwardedRef<React.ElementRef<typeof 
         ref={ref}
         {...rest}
         className={cx(
+          "timvir-b-Viewport",
           className,
           fullWidth,
           css`


### PR DESCRIPTION
To make it easier to target the blocks from automated tools (eg. for visual regression testing). The classes are aligned with the naming convention of the CSS variables that timvir blocks already use.