### PR TITLE
Remove immer and use-immer dependencies

### DIFF
--- a/.changeset/thin-pigs-camp.md
+++ b/.changeset/thin-pigs-camp.md
@@ -1,0 +1,8 @@
+---
+"timvir": patch
+---
+
+Remove immer and use-immer dependencies
+
+These dependencies did not bring enough value to the library to warrant their presence.
+This is a purely internal change and does not have any effect on the public API.

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "fuzzaldrin-plus": "^0.6.0",
     "globby": "^14.1.0",
-    "immer": "^10.1.1",
     "kleur": "^4.1.5",
     "mdast-util-from-markdown": "^2.0.2",
     "mdast-util-mdx": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "typescript": "^5.8.3",
     "unfurl.js": "^6.4.0",
     "unist-util-visit": "^5.0.0",
-    "use-immer": "^0.11.0",
     "wonka": "^6.3.5"
   }
 }

--- a/pkg/timvir/blocks/Arbitrary/Arbitrary.tsx
+++ b/pkg/timvir/blocks/Arbitrary/Arbitrary.tsx
@@ -55,7 +55,7 @@ function Arbitrary(props: Props, ref: React.ForwardedRef<React.ComponentRef<type
               onPaste={(ev) => {
                 const v = ev.clipboardData.getData("text/plain");
                 setValue({
-                  seed: +new TextDecoder().decode(base58.decode(v))
+                  seed: +new TextDecoder().decode(base58.decode(v)),
                 });
               }}
               onFocus={(ev) => {
@@ -68,7 +68,7 @@ function Arbitrary(props: Props, ref: React.ForwardedRef<React.ComponentRef<type
             className={classes.button}
             onClick={() => {
               setValue({
-                seed: crypto.getRandomValues(new Uint32Array(1))[0];
+                seed: crypto.getRandomValues(new Uint32Array(1))[0],
               });
             }}
           >

--- a/pkg/timvir/blocks/Arbitrary/Arbitrary.tsx
+++ b/pkg/timvir/blocks/Arbitrary/Arbitrary.tsx
@@ -5,7 +5,6 @@ import { Exhibit } from "timvir/blocks";
 import { useBlock } from "timvir/core";
 import * as base58 from "bytestring/base58";
 import * as React from "react";
-import { useImmer } from "use-immer";
 import { Context } from "./context";
 
 /**
@@ -22,15 +21,13 @@ function Arbitrary(props: Props, ref: React.ForwardedRef<React.ComponentRef<type
 
   const { ExhibitProps, className, children, ...rest } = block.props;
 
-  const [value, mutate] = useImmer({
-    seed: 0,
-  });
+  const [value, setValue] = React.useState({ seed: 0 });
 
   React.useEffect(() => {
-    mutate((draft) => {
-      draft.seed = crypto.getRandomValues(new Uint32Array(1))[0];
+    setValue({
+      seed: crypto.getRandomValues(new Uint32Array(1))[0],
     });
-  }, [mutate]);
+  }, []);
 
   React.useEffect(() => {
     if (props.id) {
@@ -57,8 +54,8 @@ function Arbitrary(props: Props, ref: React.ForwardedRef<React.ComponentRef<type
               readOnly
               onPaste={(ev) => {
                 const v = ev.clipboardData.getData("text/plain");
-                mutate((draft) => {
-                  draft.seed = +new TextDecoder().decode(base58.decode(v));
+                setValue({
+                  seed: +new TextDecoder().decode(base58.decode(v))
                 });
               }}
               onFocus={(ev) => {
@@ -70,8 +67,8 @@ function Arbitrary(props: Props, ref: React.ForwardedRef<React.ComponentRef<type
           <button
             className={classes.button}
             onClick={() => {
-              mutate((draft) => {
-                draft.seed = crypto.getRandomValues(new Uint32Array(1))[0];
+              setValue({
+                seed: crypto.getRandomValues(new Uint32Array(1))[0];
               });
             }}
           >

--- a/pkg/timvir/blocks/Code/Code.tsx
+++ b/pkg/timvir/blocks/Code/Code.tsx
@@ -10,7 +10,6 @@ import { useBlock } from "timvir/core";
 import { codeToHtml } from "shiki";
 import * as React from "react";
 import * as Icons from "react-feather";
-import { useImmer } from "use-immer";
 import theme from "./theme";
 
 /**
@@ -52,7 +51,7 @@ function Code(props: Props, ref: React.ForwardedRef<React.ComponentRef<typeof Ro
 
   const { children, language, fullWidth, highlightedLines, caption, className, ...rest } = block.props;
 
-  const [state, mutate] = useImmer({
+  const [state, setState] = React.useState({
     settled: false,
 
     mouseOver: false,
@@ -87,12 +86,13 @@ function Code(props: Props, ref: React.ForwardedRef<React.ComponentRef<typeof Ro
         })),
       });
 
-      mutate((draft) => {
-        draft.settled = true;
-        draft.html = html;
-      });
+      setState((state) => ({
+        ...state,
+        settled: true,
+        html,
+      }));
     })();
-  }, [mutate, children, language]);
+  }, [children, language]);
 
   return (
     <Root
@@ -107,23 +107,26 @@ function Code(props: Props, ref: React.ForwardedRef<React.ComponentRef<typeof Ro
             grid-template-columns: 1fr;
           `}
           onMouseEnter={() => {
-            mutate((draft) => {
-              draft.mouseOver = true;
-            });
+            setState((state) => ({
+              ...state,
+              mouseOver: true,
+            }));
           }}
           onMouseLeave={() => {
-            mutate((draft) => {
-              draft.mouseOver = false;
-              draft.copiedToClipboard = false;
-            });
+            setState((state) => ({
+              ...state,
+              mouseOver: false,
+              copiedToClipboard: false,
+            }));
           }}
         >
           <button
             onClick={() => {
               navigator.clipboard.writeText(children);
-              mutate((draft) => {
-                draft.copiedToClipboard = true;
-              });
+              setState((state) => ({
+                ...state,
+                copiedToClipboard: true,
+              }));
             }}
             className={cx(
               css`

--- a/pkg/timvir/blocks/Viewport/Viewport.tsx
+++ b/pkg/timvir/blocks/Viewport/Viewport.tsx
@@ -5,7 +5,6 @@ import { fullWidth, useBlock } from "timvir/core";
 import { useResizeObserver, useResizeObserverEntry } from "timvir/hooks";
 import * as React from "react";
 import { Caption, Handle, Ruler } from "./internal";
-import { useImmer } from "use-immer";
 
 /**
  * The underlying DOM element which is rendered by this component.
@@ -29,7 +28,7 @@ function Viewport(props: Props, ref: React.ForwardedRef<React.ComponentRef<typeo
 
   const { src, code, className, ...rest } = block.props;
 
-  const [state, mutate] = useImmer({
+  const [state, setState] = React.useState({
     settled: false,
   });
 
@@ -247,8 +246,8 @@ function Viewport(props: Props, ref: React.ForwardedRef<React.ComponentRef<typeo
                          * content.
                          */
                         setTimeout(() => {
-                          mutate((draft) => {
-                            draft.settled = true;
+                          setState({
+                            settled: true,
                           });
                         }, 50);
                       } else {

--- a/pkg/timvir/blocks/WebLink/WebLink.tsx
+++ b/pkg/timvir/blocks/WebLink/WebLink.tsx
@@ -3,7 +3,6 @@
 import * as React from "react";
 import { cx, css } from "@linaria/core";
 import { useContext } from "timvir/core";
-import { useImmer } from "use-immer";
 
 /**
  * The underlying DOM element which is rendered by this component.
@@ -17,7 +16,7 @@ interface Props extends React.ComponentPropsWithoutRef<typeof Root> {
 function WebLink(props: Props, ref: React.ForwardedRef<React.ComponentRef<typeof Root>>) {
   const { url, className, ...rest } = props;
 
-  const [state, mutate] = useImmer({
+  const [state, setState] = React.useState({
     settled: false,
     metadata: undefined as any,
   });
@@ -26,12 +25,12 @@ function WebLink(props: Props, ref: React.ForwardedRef<React.ComponentRef<typeof
 
   React.useEffect(() => {
     unfurl(url).then((metadata) => {
-      mutate((draft) => {
-        draft.settled = true;
-        draft.metadata = metadata;
+      setState({
+        settled: true,
+        metadata: metadata,
       });
     });
-  }, [url, mutate]);
+  }, [url]);
 
   const metadata = state.metadata;
   const image = metadata?.open_graph?.images?.[0]?.url;

--- a/pkg/timvir/core/components/Commands/internal/Dialog.tsx
+++ b/pkg/timvir/core/components/Commands/internal/Dialog.tsx
@@ -60,9 +60,10 @@ function Dialog(props: Props) {
           placeholder="Type a command or search…"
           value={state.query}
           onChange={(ev) => {
+            const query = ev.currentTarget.value;
             setState((state) => ({
               ...state,
-              query: ev.currentTarget.value,
+              query,
             }));
           }}
         />

--- a/pkg/timvir/core/components/Commands/internal/Dialog.tsx
+++ b/pkg/timvir/core/components/Commands/internal/Dialog.tsx
@@ -2,7 +2,6 @@ import { css } from "@linaria/core";
 import * as React from "react";
 import { useContext } from "timvir/context";
 import { defaultSearch } from "timvir/search";
-import { useImmer } from "use-immer";
 import Action from "./Action";
 
 interface Props {
@@ -16,7 +15,7 @@ function Dialog(props: Props) {
 
   const { open, onClose, onDispose, ...rest } = props;
 
-  const [state, mutate] = useImmer({
+  const [state, setState] = React.useState({
     style: { opacity: 0, transform: "scale(0.98)" } as React.CSSProperties,
     query: "",
 
@@ -24,27 +23,32 @@ function Dialog(props: Props) {
   });
 
   React.useEffect(() => {
-    mutate((draft) => {
-      if (open) {
-        draft.style = { opacity: 1, transform: "none" };
-      } else {
-        draft.style = { opacity: 0, transform: "scale(0.95)" };
+    if (open) {
+      setState((state) => ({
+        ...state,
+        style: { opacity: 1, transform: "none" },
+      }));
+    } else {
+      setState((state) => ({
+        ...state,
+        style: { opacity: 0, transform: "scale(0.95)" },
+      }));
 
-        setTimeout(() => {
-          onDispose?.();
-        }, 200);
-      }
-    });
-  }, [mutate, open]);
+      setTimeout(() => {
+        onDispose?.();
+      }, 200);
+    }
+  }, [open]);
 
   React.useEffect(() => {
     (async () => {
       const { edges } = await defaultSearch(toc).q(state.query);
-      mutate((draft) => {
-        draft.commands = edges;
-      });
+      setState((state) => ({
+        ...state,
+        commands: edges,
+      }));
     })();
-  }, [mutate, state.query]);
+  }, [state.query]);
 
   return (
     <div className={classes.root} style={state.style} {...rest}>
@@ -56,10 +60,10 @@ function Dialog(props: Props) {
           placeholder="Type a command or search…"
           value={state.query}
           onChange={(ev) => {
-            const query = ev.currentTarget.value;
-            mutate((draft) => {
-              draft.query = query;
-            });
+            setState((state) => ({
+              ...state,
+              query: ev.currentTarget.value,
+            }));
           }}
         />
       </div>

--- a/pkg/timvir/core/components/Page/Page.tsx
+++ b/pkg/timvir/core/components/Page/Page.tsx
@@ -6,7 +6,6 @@ import * as React from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { makeBus } from "timvir/bus";
 import { Provider, Value } from "timvir/context";
-import { useImmer } from "use-immer";
 import { grid } from "../../layout";
 import { theme } from "../../theme";
 import { Commands } from "../Commands";
@@ -74,7 +73,7 @@ interface Props extends React.ComponentProps<typeof Root> {
 function Page(props: Props, ref: React.ForwardedRef<React.ComponentRef<typeof Root>>) {
   const { location, toc, Link, className, search, mdxComponents, Footer, blocks, children, ...rest } = props;
 
-  const [state, mutate] = useImmer({
+  const [state, setState] = React.useState({
     search: {
       open: false,
     },
@@ -96,8 +95,10 @@ function Page(props: Props, ref: React.ForwardedRef<React.ComponentRef<typeof Ro
     "meta+p",
     (ev) => {
       ev.preventDefault();
-      mutate((draft) => {
-        draft.search.open = !draft.search.open;
+      setState({
+        search: {
+          open: !state.search.open,
+        },
       });
     },
     { enableOnFormTags: true }
@@ -106,8 +107,10 @@ function Page(props: Props, ref: React.ForwardedRef<React.ComponentRef<typeof Ro
   useHotkeys(
     "escape",
     () => {
-      mutate((draft) => {
-        draft.search.open = false;
+      setState({
+        search: {
+          open: false,
+        },
       });
     },
     { enableOnFormTags: true }
@@ -159,8 +162,10 @@ function Page(props: Props, ref: React.ForwardedRef<React.ComponentRef<typeof Ro
           search={
             search && {
               open: () => {
-                mutate((draft) => {
-                  draft.search.open = true;
+                setState({
+                  search: {
+                    open: true,
+                  },
                 });
               },
               ...search,
@@ -239,8 +244,10 @@ function Page(props: Props, ref: React.ForwardedRef<React.ComponentRef<typeof Ro
           <search.Component
             {...state.search}
             onClose={() => {
-              mutate((draft) => {
-                draft.search.open = false;
+              setState({
+                search: {
+                  open: false,
+                },
               });
             }}
           />

--- a/pkg/timvir/core/index.ts
+++ b/pkg/timvir/core/index.ts
@@ -56,7 +56,7 @@ export function useBlock<P extends { id?: string }>(props: P) {
           }
         })
       ).unsubscribe,
-    [mailbox, setState]
+    [mailbox]
   );
 
   return {

--- a/pkg/timvir/core/index.ts
+++ b/pkg/timvir/core/index.ts
@@ -65,8 +65,8 @@ export function useBlock<P extends { id?: string }>(props: P) {
     props: { ...props, ...state.overrides },
     hasOverrides: !!state.overrides,
     reset: () => {
-      mutate((draft) => {
-        draft.overrides = undefined;
+      setState({
+        overrides: undefined,
       });
     },
   };

--- a/pkg/timvir/core/index.ts
+++ b/pkg/timvir/core/index.ts
@@ -2,7 +2,6 @@ import { filter, pipe, Source, subscribe } from "wonka";
 import { Message } from "timvir/bus";
 import { useContext } from "timvir/context";
 import * as React from "react";
-import { useImmer } from "use-immer";
 
 export * from "./components/Footer";
 export * from "./components/Page";
@@ -31,7 +30,7 @@ export function useBlock<P extends { id?: string }>(props: P) {
   const { bus } = useContext();
   const mailbox = useMailbox(props.id);
 
-  const [state, mutate] = useImmer({
+  const [state, setState] = React.useState({
     overrides: undefined as undefined | Partial<P>,
   });
 
@@ -42,22 +41,22 @@ export function useBlock<P extends { id?: string }>(props: P) {
         subscribe((msg: Message) => {
           if (msg.interface === "dev.timvir.Props") {
             if (msg.member === "set") {
-              mutate((draft) => {
-                draft.overrides = msg.body as any;
+              setState({
+                overrides: msg.body as any,
               });
             } else if (msg.member === "merge") {
-              mutate((draft) => {
-                draft.overrides = { ...(draft.overrides as any), ...(msg.body as any) };
+              setState({
+                overrides: { ...(state.overrides as any), ...(msg.body as any) },
               });
             } else if (msg.member === "reset") {
-              mutate((draft) => {
-                draft.overrides = undefined;
+              setState({
+                overrides: undefined,
               });
             }
           }
         })
       ).unsubscribe,
-    [mailbox, mutate]
+    [mailbox, setState]
   );
 
   return {

--- a/pkg/timvir/package.json
+++ b/pkg/timvir/package.json
@@ -19,7 +19,6 @@
     "bytestring": "^1",
     "downshift": "^7 || ^8 || ^9",
     "fuzzaldrin-plus": "^0.6.0",
-    "immer": "^9 || ^10",
     "shiki": "^1 || ^2 || ^3",
     "react-feather": "^2",
     "wonka": "^6"

--- a/pkg/timvir/package.json
+++ b/pkg/timvir/package.json
@@ -22,7 +22,6 @@
     "immer": "^9 || ^10",
     "shiki": "^1 || ^2 || ^3",
     "react-feather": "^2",
-    "use-immer": "^0.8.0 || ^0.8.1 || ^0.9.0 || ^0.10.0 || ^0.11.0",
     "wonka": "^6"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,9 +161,6 @@ importers:
       globby:
         specifier: ^14.1.0
         version: 14.1.0
-      immer:
-        specifier: ^10.1.1
-        version: 10.1.1
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
@@ -296,9 +293,6 @@ importers:
       fuzzaldrin-plus:
         specifier: ^0.6.0
         version: 0.6.0
-      immer:
-        specifier: ^9 || ^10
-        version: 10.1.1
       react:
         specifier: ^17 || ^18 || ^19
         version: 19.1.0
@@ -314,9 +308,6 @@ importers:
       shiki:
         specifier: ^1 || ^2 || ^3
         version: 3.2.2
-      use-immer:
-        specifier: ^0.8.0 || ^0.8.1 || ^0.9.0 || ^0.10.0 || ^0.11.0
-        version: 0.11.0(immer@10.1.1)(react@19.1.0)
       wonka:
         specifier: ^6
         version: 6.3.5
@@ -2606,9 +2597,6 @@ packages:
     resolution: {integrity: sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==}
     engines: {node: '>= 4'}
 
-  immer@10.1.1:
-    resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
-
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
@@ -3941,12 +3929,6 @@ packages:
 
   uri-js@4.2.2:
     resolution: {integrity: sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==}
-
-  use-immer@0.11.0:
-    resolution: {integrity: sha512-RNAqi3GqsWJ4bcCd4LMBgdzvPmTABam24DUaFiKfX9s3MSorNRz9RDZYJkllJoMHUxVLMDetwAuCDeyWNrp1yA==}
-    peerDependencies:
-      immer: '>=8.0.0'
-      react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -6859,8 +6841,6 @@ snapshots:
 
   ignore@7.0.3: {}
 
-  immer@10.1.1: {}
-
   import-fresh@3.3.0:
     dependencies:
       parent-module: 1.0.1
@@ -8439,11 +8419,6 @@ snapshots:
   uri-js@4.2.2:
     dependencies:
       punycode: 2.1.1
-
-  use-immer@0.11.0(immer@10.1.1)(react@19.1.0):
-    dependencies:
-      immer: 10.1.1
-      react: 19.1.0
 
   util-deprecate@1.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,9 +227,6 @@ importers:
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
-      use-immer:
-        specifier: ^0.11.0
-        version: 0.11.0(immer@10.1.1)(react@19.1.0)
       wonka:
         specifier: ^6.3.5
         version: 6.3.5


### PR DESCRIPTION
The `immer` and `use-immer` dependencies do not bring enough value to this library to warrant their presence. In many cases, we only need to store a single value in the local state, such as here for example:

```jsx
const [value, mutate] = useImmer({
  seed: 0,
});
```

Such cases can easily be replaced with the standard React `useState()`. In a few cases we store two or three distinct things. But the local state is never complex enough (or deeply nested) such that Immer's draft mechanism, object freezing would bring enough value.

For an web application, Immer is fine. Or when you heavily rely on its advanced features. For a library like Timvir, it's overkill.

Yes I realize that the library has far larger dependencies. Shiki being the biggest one. But Immer is the easiest to drop :)

<img width="803" alt="image" src="https://github.com/user-attachments/assets/8fc0e9e5-fdc7-42ed-8d99-ab614b1e136e" />

