### PR TITLE
Wait for load event instead of domcontentloaded

### DIFF
--- a/urnerys/blocks.spec.ts
+++ b/urnerys/blocks.spec.ts
@@ -62,7 +62,7 @@ for (const url of urls) {
   test(url, async ({ page }, { title, project }) => {
     const imageUploads: Array<Promise<unknown>> = [];
 
-    await page.goto(url, { waitUntil: "domcontentloaded" });
+    await page.goto(url);
 
     const inputElements = await page.$$(".timvir-b-Arbitrary-seed");
     for (const inputElement of inputElements) {

--- a/urnerys/blocks.spec.ts
+++ b/urnerys/blocks.spec.ts
@@ -62,7 +62,7 @@ for (const url of urls) {
   test(url, async ({ page }, { title, project }) => {
     const imageUploads: Array<Promise<unknown>> = [];
 
-    await page.goto(url);
+    await page.goto(url, { waitUntil: "load" });
 
     const inputElements = await page.$$(".timvir-b-Arbitrary-seed");
     for (const inputElement of inputElements) {

--- a/urnerys/pages.spec.ts
+++ b/urnerys/pages.spec.ts
@@ -53,7 +53,7 @@ for (const url of urls) {
   test(url, async ({ page }, { title, project }) => {
     const imageUploads: Array<Promise<unknown>> = [];
 
-    await page.goto(url);
+    await page.goto(url, { waitUntil: "load" });
 
     const inputElements = await page.$$(".timvir-b-Arbitrary-seed");
     for (const inputElement of inputElements) {

--- a/urnerys/pages.spec.ts
+++ b/urnerys/pages.spec.ts
@@ -53,7 +53,7 @@ for (const url of urls) {
   test(url, async ({ page }, { title, project }) => {
     const imageUploads: Array<Promise<unknown>> = [];
 
-    await page.goto(url, { waitUntil: "domcontentloaded" });
+    await page.goto(url);
 
     const inputElements = await page.$$(".timvir-b-Arbitrary-seed");
     for (const inputElement of inputElements) {


### PR DESCRIPTION
The tests interact with the web pages. In particular, on the `/blocks/Arbitrary` page, the test sends a `ClipboardEvent` to the block to set a predictable seed. Because we are only waiting for `domcontentloaded`, the page is not hydrated yet, event handlers are not attached to the elements, and therefore this event is lost. This leads to spurious image diffs because the seed is random.

Use the default waitUntil condition - `load`. When that event fires, React will have fully hydrated the page.