### PR TITLE
Set a minimum release age for renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,8 @@
   "prHourlyLimit": 0,
   "postUpdateOptions": ["pnpmDedupe"],
   "dependencyDashboardApproval": true,
+  "minimumReleaseAge": "9 days",
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "matchFileNames": [


### PR DESCRIPTION
In the past week on two separate occasions NPM packages have been published that contained malware. Sadly, very few developers generate [provenance statements](https://docs.npmjs.com/generating-provenance-statements) or publish using [trusted publishers](https://docs.npmjs.com/trusted-publishers).

Usually these malicious packages are pulled within a couple hours (or days at most). In light of that, set `minimumReleaseAge` to 9 days to avoid even considering young packages for update. After having aged for 9 days, packages can be considered safe (from both a security standpoint and also not having introduced any major unintended breaking changes or bugs). 9 days may seem a lot, but we're not trying to live on the edge here. The lowest I would recommend is 3, because [this](https://docs.renovatebot.com/configuration-options/#prevent-holding-broken-npm-packages):

> npm packages less than 72 hours (3 days) old can be unpublished from the npm registry, which could result in a service impact if you have already updated to it. Set minimumReleaseAge to 3 days for npm packages to prevent relying on a package that can be removed from the registry